### PR TITLE
Simplify identifier verification to three states: verified, not found…

### DIFF
--- a/streamlit-app/ui/report_panel.py
+++ b/streamlit-app/ui/report_panel.py
@@ -337,9 +337,11 @@ def _run_and_save_verification(db_manager, report_id: str, report_md: str, log, 
         results = verify_report(report_md, drug_name=drug_name)
 
         total = len(results)
-        verified = sum(1 for r in results.values() if r["valid"])
-        unverified = total - verified
-        rate = round(unverified / total, 3) if total > 0 else 0.0
+        verified = sum(1 for r in results.values() if r["valid"] is True)
+        not_found = sum(1 for r in results.values() if r["valid"] is False)
+        unverified = not_found  # rate-limited excluded from hallucination score
+        checkable = sum(1 for r in results.values() if r["valid"] is not None)
+        rate = round(not_found / checkable, 3) if checkable > 0 else 0.0
 
         st.session_state["hallucination_check"] = results
         st.session_state["hallucination_rate"] = rate
@@ -456,16 +458,15 @@ def _render_verification_results() -> None:
         st.info("No verifiable identifiers (NCT numbers, PMIDs, DOIs) found in this report.")
         return
 
-    invalid    = {k: v for k, v in results.items() if not v["valid"]}
-    wrong_drug = {k: v for k, v in results.items() if v["valid"] and v.get("drug_match") is False}
-    verified   = {k: v for k, v in results.items() if v["valid"] and v.get("drug_match") is not False}
+    invalid      = {k: v for k, v in results.items() if v["valid"] is False}
+    unverifiable = {k: v for k, v in results.items() if v["valid"] is None}
+    verified     = {k: v for k, v in results.items() if v["valid"] is True}
 
-    label = (
-        f"Identifier Verification — "
-        f"{len(verified)} verified ✓  |  "
-        f"{len(wrong_drug)} wrong drug ⚠  |  "
-        f"{len(invalid)} not found ✗"
-    )
+    label_parts = [f"{len(verified)} verified ✓", f"{len(invalid)} not found ✗"]
+    if unverifiable:
+        label_parts.append(f"{len(unverifiable)} unverifiable ~")
+    label = "Identifier Verification — " + "  |  ".join(label_parts)
+
     with st.expander(label, expanded=len(invalid) > 0 or len(wrong_drug) > 0):
         if invalid:
             st.markdown(
@@ -483,18 +484,18 @@ def _render_verification_results() -> None:
                     f"</div>",
                     unsafe_allow_html=True,
                 )
-        if wrong_drug:
+        if unverifiable:
             st.markdown(
                 f"<div style='font-size:0.8rem;font-weight:600;margin:0.6rem 0 0.5rem'>"
-                f"⚠ {len(wrong_drug)} NCT number(s) exist but don't match the research drug</div>",
+                f"~ {len(unverifiable)} identifier(s) could not be verified (rate limited)</div>",
                 unsafe_allow_html=True,
             )
-            for id_val, r in wrong_drug.items():
+            for id_val, r in unverifiable.items():
                 st.markdown(
-                    f"<div class='verify-card verify-warn'>"
-                    f"<span class='verify-icon'>⚠</span>"
+                    f"<div class='verify-card' style='border-left:3px solid #888'>"
+                    f"<span class='verify-icon'>~</span>"
                     f"<div><code style='font-size:0.8rem'>{id_val}</code> "
-                    f"<span style='font-size:0.75rem;opacity:0.7'>(NCT)</span>"
+                    f"<span style='font-size:0.75rem;opacity:0.7'>({r['type'].upper()})</span>"
                     f"<br><span style='font-size:0.78rem'>{r['details']}</span></div>"
                     f"</div>",
                     unsafe_allow_html=True,

--- a/streamlit-app/utils/hallucination_checker.py
+++ b/streamlit-app/utils/hallucination_checker.py
@@ -41,46 +41,25 @@ def extract_identifiers(report_md: str) -> Dict[str, List[str]]:
 # Per-type verifiers
 # ---------------------------------------------------------------------------
 
-def _check_drug_in_trial(data: dict, drug_name: str) -> bool:
-    """Return True if drug_name appears in the trial title or interventions."""
-    protocol = data.get("protocolSection", {})
-    title = protocol.get("identificationModule", {}).get("briefTitle", "")
-    interventions = [
-        i.get("name", "")
-        for i in protocol.get("armsInterventionsModule", {}).get("interventions", [])
-    ]
-    all_text = (title + " " + " ".join(interventions)).lower()
-    drug_lower = drug_name.lower()
-    if drug_lower in all_text:
-        return True
-    # Also check individual words (skip short words to avoid false matches)
-    words = [w for w in drug_lower.split() if len(w) > 3]
-    return any(w in all_text for w in words) if words else False
 
-
-def _verify_nct(nct_id: str, drug_name: str = None) -> Tuple:
-    """Verify NCT number. Returns (valid, details, drug_match) where drug_match
-    is True/False if drug_name provided, None otherwise."""
+def _verify_nct(nct_id: str, drug_name: str = None) -> Tuple[bool, str]:
+    """Verify NCT number exists on ClinicalTrials.gov."""
     url = f"https://clinicaltrials.gov/api/v2/studies/{nct_id}"
     try:
         with urlopen(Request(url, headers={"Accept": "application/json"}), timeout=REQUEST_TIMEOUT) as resp:
             if resp.status == 200:
-                if drug_name:
-                    data = json.loads(resp.read())
-                    drug_match = _check_drug_in_trial(data, drug_name)
-                    if drug_match:
-                        return True, "verified on ClinicalTrials.gov", True
-                    return True, "trial exists but does not involve this drug", False
-                return True, "verified on ClinicalTrials.gov", None
+                return True, "verified on ClinicalTrials.gov"
     except HTTPError as e:
         if e.code == 404:
-            return False, "not found on ClinicalTrials.gov", None
-        return False, f"HTTP {e.code}", None
+            return False, "not found on ClinicalTrials.gov"
+        if e.code == 429:
+            return None, "rate limited — could not verify"
+        return False, f"HTTP {e.code}"
     except URLError as e:
-        return False, f"network error: {e.reason}", None
+        return False, f"network error: {e.reason}"
     except Exception as e:
-        return False, f"error: {e}", None
-    return False, "unexpected response", None
+        return False, f"error: {e}"
+    return False, "unexpected response"
 
 
 def _verify_pmid(pmid: str) -> Tuple[bool, str]:
@@ -98,6 +77,8 @@ def _verify_pmid(pmid: str) -> Tuple[bool, str]:
                 return True, f'verified: "{title}"' if title else "verified on PubMed"
             return False, "ID not found in PubMed"
     except HTTPError as e:
+        if e.code == 429:
+            return None, "rate limited — could not verify"
         return False, f"HTTP {e.code}"
     except URLError as e:
         return False, f"network error: {e.reason}"
@@ -114,6 +95,8 @@ def _verify_doi(doi: str) -> Tuple[bool, str]:
                 return True, "verified on doi.org"
             return False, f"unresolvable (responseCode {data.get('responseCode')})"
     except HTTPError as e:
+        if e.code == 429:
+            return None, "rate limited — could not verify"
         return False, f"HTTP {e.code}"
     except URLError as e:
         return False, f"network error: {e.reason}"
@@ -158,20 +141,14 @@ def verify_report(report_md: str, drug_name: str = None, max_workers: int = 8) -
     results: Dict[str, Dict] = {}
     with ThreadPoolExecutor(max_workers=max_workers) as pool:
         future_map = {
-            pool.submit(_verify_nct, id_val, drug_name) if id_type == "nct"
-            else pool.submit(_VERIFIERS[id_type], id_val): (id_val, id_type)
+            pool.submit(_VERIFIERS[id_type], id_val): (id_val, id_type)
             for id_val, id_type in tasks
         }
         for future in as_completed(future_map):
             id_val, id_type = future_map[future]
             try:
-                result = future.result()
-                if id_type == "nct":
-                    valid, details, drug_match = result
-                    results[id_val] = {"type": id_type, "valid": valid, "details": details, "drug_match": drug_match}
-                else:
-                    valid, details = result
-                    results[id_val] = {"type": id_type, "valid": valid, "details": details}
+                valid, details = future.result()
+                results[id_val] = {"type": id_type, "valid": valid, "details": details}
             except Exception as e:
                 results[id_val] = {"type": id_type, "valid": False, "details": f"check failed: {e}"}
 


### PR DESCRIPTION
- Remove drug-trial cross-check from NCT verification (was producing false positives)
- HTTP 429 (rate limit) now returns None valid instead of False for PMID, DOI, and NCT
- Rate-limited identifiers shown as unverifiable in UI, excluded from hallucination rate
- Hallucination rate now calculated only over identifiers with definitive responses